### PR TITLE
Add gold

### DIFF
--- a/src/SocketIoServer.js
+++ b/src/SocketIoServer.js
@@ -1,5 +1,6 @@
 const debug = require('debug')('thmix:SocketIoServer');
 const SocketIoSession = require('./SocketIoSession');
+const {User} = require('./models');
 
 const VERSION = 0;
 
@@ -27,6 +28,11 @@ module.exports = class SocketIoServer {
 
     /** @type {import('./WebSocketServer')} */
     this.webSocketServer = null;
+
+    setInterval(() => {
+      debug('new day login');
+      User.updateMany({newDay: false}, {$set: {newDay: true}}).exec();
+    }, 1000 * 60 * 60 * 24);
 
     this.revision = require('child_process')
         .execSync('git rev-parse HEAD')

--- a/src/WebSocketSession.js
+++ b/src/WebSocketSession.js
@@ -198,7 +198,10 @@ module.exports = class WebSocketSession {
     if (hash !== user.hash) return this.returnError(id, 'wrong combination');
 
     this.user = user;
-    this.user = await this.updateUser({seenDate: new Date()});
+    if (user.newDay) {
+      await User.updateOne({_id: user._id}, {$inc: {gold: 10}});
+    }
+    this.user = await this.updateUser({seenDate: new Date(), newDay: false});
 
     await SessionToken.updateMany({userId: user._id, valid: true}, {
       $set: {valid: false, invalidatedDate: new Date()},
@@ -296,6 +299,7 @@ module.exports = class WebSocketSession {
       version, duration,
     } = trial;
     const performance = Math.log(1 + score) * Math.pow(accuracy, 2);
+    const gold = Math.ceil(performance);
     const grade = withdrew ? 'W' : getGradeFromAccuracy(accuracy);
     const gradeLevel = withdrew ? 'F' : getGradeLevelFromAccuracy(accuracy);
     duration = parseInt(duration || 0);
@@ -313,6 +317,7 @@ module.exports = class WebSocketSession {
       score,
       combo,
       performance,
+      gold,
       accuracy,
     };
 

--- a/src/models.js
+++ b/src/models.js
@@ -38,6 +38,8 @@ exports.User = mongoose.model('User', new mongoose.Schema({
   onlineTime: Number,
   performance: Number,
   ranking: Number,
+  gold: Number,
+  newDay: Boolean,
 
   sCount: Number,
   aCount: Number,
@@ -53,7 +55,7 @@ exports.serializeUser = function(user) {
     name, joinedDate, seenDate, bio, avatarUrl, roles,
     trialCount, score, combo, accuracy,
     playTime, onlineTime,
-    performance, ranking, sCount, aCount, bCount, cCount, dCount, fCount,
+    performance, ranking, gold, sCount, aCount, bCount, cCount, dCount, fCount,
   } = user;
   return {
     id,
@@ -61,7 +63,7 @@ exports.serializeUser = function(user) {
     trialCount, score, combo, accuracy,
     avgScore: score / trialCount, avgCombo: combo / trialCount, avgAccuracy: accuracy / trialCount,
     playTime, onlineTime,
-    performance, ranking, sCount, aCount, bCount, cCount, dCount, fCount,
+    performance, ranking, gold, sCount, aCount, bCount, cCount, dCount, fCount,
     passCount: trialCount - fCount, failCount: fCount,
   };
 };
@@ -88,6 +90,8 @@ exports.createDefaultUser = function() {
     playTime: 0,
     performance: 0,
     ranking: 0,
+    gold: 0,
+    newDay: true,
     sCount: 0,
     aCount: 0,
     bCount: 0,


### PR DESCRIPTION
All users can gain gold which is the same amount as their current performance.
Use 
```db.users.aggregate([{'$addFields': {'gold': {$ceil: '$performance'}}}, {'$out': 'users'}]) ```
to perform the update.

Let users get gold which is the same amount as performance for each song they play.
Let users get 10 gold each day for logging in app.