### PR TITLE
Add Event

### DIFF
--- a/src/SocketIoSession.js
+++ b/src/SocketIoSession.js
@@ -15,6 +15,7 @@ const {
   ROLE_MIDI_ADMIN,
   ROLE_CARD_MOD,
   ROLE_CARDPOOL_MOD,
+  ROLE_EVENT_MOD,
   ROLE_TRANSLATION_MOD,
   ROLE_SITE_OWNER,
   checkUserRole,
@@ -37,6 +38,7 @@ const {
   Card, createDefaultCard, serializeCard,
   CardPool, createDefaultCardPool, serializeCardPool,
   serializeRanking,
+  Event, createDefaultEvent, serializeEvent,
 } = require('./models');
 const {NAME_ARTIFACT, UI_APP, UI_WEB} = require('./TranslationService');
 
@@ -110,6 +112,8 @@ const CARD_COVER_HEIGHT = 200;
 const CARD_COVER_WIDTH = 150;
 const COVER_HEIGHT = 250;
 const COVER_WIDTH = 900;
+const EVENT_COVER_HEIGHT = 600;
+const EVENT_COVER_WIDTH = 900;
 
 module.exports = class SocketIoSession {
   /**
@@ -274,6 +278,13 @@ module.exports = class SocketIoSession {
     this.socket.on('ClWebCardPoolGet', createRpcHandler(this.onClWebCardPoolGet.bind(this)));
     this.socket.on('ClWebCardPoolUpdate', createRpcHandler(this.onClWebCardPoolUpdate.bind(this)));
     this.socket.on('ClWebCardPoolList', createRpcHandler(this.onClWebCardPoolList.bind(this)));
+
+    this.socket.on('ClWebEventCreate', createRpcHandler(this.onClWebEventCreate.bind(this)));
+    this.socket.on('ClWebEventGet', createRpcHandler(this.onClWebEventGet.bind(this)));
+    this.socket.on('ClWebEventGetMidiList', createRpcHandler(this.onClWebEventGetMidiList.bind(this)));
+    this.socket.on('ClWebEventUploadCover', createRpcHandler(this.onClWebEventUploadCover.bind(this)));
+    this.socket.on('ClWebEventUpdate', createRpcHandler(this.onClWebEventUpdate.bind(this)));
+    this.socket.on('ClWebEventRanking', createRpcHandler(this.onClWebEventRanking.bind(this)));
 
     this.socket.on('cl_web_person_create', this.onClWebPersonCreate.bind(this));
     this.socket.on('cl_web_person_get', this.onClWebPersonGet.bind(this));
@@ -1645,5 +1656,128 @@ module.exports = class SocketIoSession {
       {$group: {_id: '$sourceAlbumName', songs: {$push: {_id: '$_id', midiIds: '$midiIds'}}}},
     ]);
     return res;
+  }
+
+  async onClWebEventCreate() {
+    debug('  onClWebEventCreate');
+
+    if (!this.checkUserRole(ROLE_EVENT_MOD)) throw codeError(0, ERROR_FORBIDDEN);
+
+    const event = await Event.create({
+      ...createDefaultEvent(),
+    });
+    return {id: event.id};
+  }
+
+  async onClWebEventGet({id}) {
+    debug('  onClWebEventGet', id);
+
+    if (!verifyObjectId(id)) throw codeError(0, 'not found');
+
+    const event = await Event.findById(id);
+    if (!event) throw codeError(1, 'not found');
+
+    return serializeEvent(event);
+  }
+
+  async onClWebEventGetMidiList({id}) {
+    debug('  onClWebEventGetMidiList', id);
+
+    if (!verifyObjectId(id)) throw codeError(0, 'not found');
+
+    const event = await Event.aggregate([
+      {$match: {_id: new ObjectId(id)}},
+      {$lookup: {from: 'midis', localField: 'midiIds', foreignField: '_id', as: 'midis'}},
+    ]);
+
+    if (!event) throw codeError(1, 'not found');
+
+    return serializeEvent(event[0]);
+  }
+
+  async onClWebEventUploadCover({id, size, buffer}) {
+    debug('  onClWebEventUploadCover', id, size, buffer.length);
+
+    if (!this.checkUserRole(ROLE_EVENT_MOD)) throw codeError(0, ERROR_FORBIDDEN);
+    if (!verifyObjectId(id)) throw codeError(1, ERROR_FORBIDDEN);
+    if (size !== buffer.length) throw codeError(2, 'tampering with api');
+    if (size > 5 * MB) throw codeError(3, 'too large');
+
+    let event = await Event.findById(id);
+    if (!event) throw codeError(4, 'not found');
+
+    const paths = await this.uploadCover(buffer, EVENT_COVER_HEIGHT, EVENT_COVER_WIDTH);
+
+    event = await Event.findByIdAndUpdate(id, {$set: {
+      coverPath: paths.coverPath,
+    }}, {new: true});
+
+    return serializeEvent(event);
+  }
+
+  async onClWebEventUpdate(update) {
+    debug('  onClWebEventUpdate');
+    if (!this.checkUserRole(ROLE_EVENT_MOD)) throw codeError(0, ERROR_FORBIDDEN);
+
+    const {
+      id, startDate, endDate, name, desc, midiIds, active,
+    } = update;
+
+    if (!verifyObjectId(id)) throw codeError(1, ERROR_FORBIDDEN);
+
+    let event = await Event.findById(id);
+    if (!event) throw codeError(2, 'not found');
+
+    update = filterUndefinedKeys({
+      startDate, endDate, name, desc, midiIds, active,
+    });
+
+    event = await Event.findByIdAndUpdate(id, {$set: update}, {new: true});
+    return serializeEvent(event);
+  }
+
+  async onClWebEventRanking({id}) {
+    debug('  onClWebEventRanking', id);
+
+    const event = await Event.findById(id);
+    if (!event) throw codeError(0, 'not found');
+
+    const pipeline = [];
+
+    pipeline.push({$match: {$and: [{withdrew: false, eventId: new ObjectId(id), date: {$gte: event.startDate, $lte: event.endDate}}]}});
+    pipeline.push({$group: {
+      _id: '$userId',
+      playTime: {$sum: '$duration'},
+      trialCount: {$sum: 1},
+      score: {$sum: '$score'},
+      avgCombo: {$avg: '$combo'},
+      avgAccuracy: {$avg: '$accuracy'},
+      performance: {$sum: '$performance'},
+    }});
+    pipeline.push({$lookup: {from: 'users', localField: '_id', foreignField: '_id', as: 'user'}});
+    pipeline.push({$unwind: {path: '$user', preserveNullAndEmptyArrays: true}});
+    pipeline.push({$addFields: {
+      'user.playTime': '$playTime',
+      'user.trialCount': '$trialCount',
+      'user.score': '$score',
+      'user.avgCombo': '$avgCombo',
+      'user.avgAccuracy': '$avgAccuracy',
+      'user.performance': '$performance',
+    }});
+    pipeline.push({$replaceRoot: {newRoot: '$user'}});
+    pipeline.push({$sort: {performance: -1}});
+
+    const rankings = await Trial.aggregate(pipeline);
+
+    if (!this.user) return rankings.map((x) => serializeRanking(x));
+
+    pipeline[0] = {$match: {$and: [{withdrew: false, userId: new ObjectId(this.user.id), eventId: new ObjectId(id)}]}};
+    let user = await Trial.aggregate(pipeline);
+    user = user[0];
+
+    if (!user) return {rankings: rankings.map((x) => serializeRanking(x)), userRanking: -1};
+
+    const userRanking = rankings.findIndex((x) => x._id.equals(user._id));
+    return {rankings: rankings.map((x) => serializeRanking(x)), userRanking, userRankingDetail: serializeRanking(user)};
   }
 };

--- a/src/SocketIoSession.js
+++ b/src/SocketIoSession.js
@@ -1742,7 +1742,8 @@ module.exports = class SocketIoSession {
     const event = await Event.findById(id);
     if (!event) throw codeError(0, 'not found');
 
-    const pipeline = [{$match: {$and: [{withdrew: false, eventId: new ObjectId(id), date: {$gte: event.startDate, $lte: event.endDate}}]}},
+    const pipeline = [
+      {$match: {withdrew: false, eventId: new ObjectId(id), date: {$gte: event.startDate, $lte: event.endDate}}},
       {$group: {
         _id: '$userId',
         playTime: {$sum: '$duration'},
@@ -1770,7 +1771,7 @@ module.exports = class SocketIoSession {
 
     if (!this.user) return rankings.map((x) => serializeRanking(x));
 
-    pipeline[0] = {$match: {$and: [{withdrew: false, userId: new ObjectId(this.user.id), eventId: new ObjectId(id)}]}};
+    pipeline[0] = {$match: {withdrew: false, userId: new ObjectId(this.user.id), eventId: new ObjectId(id)}};
     let user = await Trial.aggregate(pipeline);
     user = user[0];
 

--- a/src/SocketIoSession.js
+++ b/src/SocketIoSession.js
@@ -1720,7 +1720,7 @@ module.exports = class SocketIoSession {
     if (!this.checkUserRole(ROLE_EVENT_MOD)) throw codeError(0, ERROR_FORBIDDEN);
 
     const {
-      id, startDate, endDate, name, desc, midiIds, active,
+      id, startDate, endDate, name, desc, midiIds,
     } = update;
 
     if (!verifyObjectId(id)) throw codeError(1, ERROR_FORBIDDEN);
@@ -1729,7 +1729,7 @@ module.exports = class SocketIoSession {
     if (!event) throw codeError(2, 'not found');
 
     update = filterUndefinedKeys({
-      startDate, endDate, name, desc, midiIds, active,
+      startDate, endDate, name, desc, midiIds,
     });
 
     event = await Event.findByIdAndUpdate(id, {$set: update}, {new: true});

--- a/src/WebSocketSession.js
+++ b/src/WebSocketSession.js
@@ -414,14 +414,15 @@ module.exports = class WebSocketSession {
         {$match: {midiIds: new ObjectId(midi._id)}},
       ]);
 
-      if (eventIds) eventId = eventIds[0];
+      if (eventIds[0]) {
+        eventId = eventIds[0]._id;
+        await User.updateOne({_id: this.user.id}, {$inc: {gold: Math.ceil(performance)}});
+      }
 
       this.user = await this.updateUser({$inc});
       midi = await Midi.findOneAndUpdate({hash}, {$inc});
-      if (eventId) {
-        await User.updateOne({_id: this.user.id}, {$inc: {gold: Math.ceil(performance)}});
-      }
     }
+
     this.user = await this.updateUser({$inc: {
       playTime: duration,
     }});

--- a/src/WebSocketSession.js
+++ b/src/WebSocketSession.js
@@ -414,7 +414,7 @@ module.exports = class WebSocketSession {
       ]);
       if (eventIds[0]) {
         eventId = eventIds[0]._id;
-        await User.updateOne({_id: this.user.id}, {$inc: {gold: Math.ceil(performance)}});
+        $inc.gold += gold;
       }
 
       this.user = await this.updateUser({$inc});

--- a/src/WebSocketSession.js
+++ b/src/WebSocketSession.js
@@ -407,7 +407,7 @@ module.exports = class WebSocketSession {
     let eventId = undefined;
     if (!withdrew) {
       const eventIds = await Event.aggregate([
-        {$match: {$and: [{startDate: {$lte: new Date()}, endDate: {$gte: new Date()}}]}},
+        {$match: {startDate: {$lte: new Date()}, endDate: {$gte: new Date()}}},
         {$project: {midiIds: 1}},
         {$unwind: {path: '$midiIds', preserveNullAndEmptyArrays: true}},
         {$match: {midiIds: new ObjectId(midi._id)}},

--- a/src/WebSocketSession.js
+++ b/src/WebSocketSession.js
@@ -416,7 +416,6 @@ module.exports = class WebSocketSession {
         eventId = eventIds[0]._id;
         $inc.gold += gold;
       }
-
       this.user = await this.updateUser({$inc});
       midi = await Midi.findOneAndUpdate({hash}, {$inc});
     }

--- a/src/WebSocketSession.js
+++ b/src/WebSocketSession.js
@@ -405,7 +405,6 @@ module.exports = class WebSocketSession {
     };
 
     let eventId = undefined;
-
     if (!withdrew) {
       const eventIds = await Event.aggregate([
         {$match: {$and: [{startDate: {$lte: new Date()}, endDate: {$gte: new Date()}}]}},
@@ -413,7 +412,6 @@ module.exports = class WebSocketSession {
         {$unwind: {path: '$midiIds', preserveNullAndEmptyArrays: true}},
         {$match: {midiIds: new ObjectId(midi._id)}},
       ]);
-
       if (eventIds[0]) {
         eventId = eventIds[0]._id;
         await User.updateOne({_id: this.user.id}, {$inc: {gold: Math.ceil(performance)}});

--- a/src/models.js
+++ b/src/models.js
@@ -380,6 +380,7 @@ exports.Trial = mongoose.model('Trial', new mongoose.Schema({
   goodCount: Number,
   badCount: Number,
   missCount: Number,
+  eventId: ObjectId,
 }));
 
 function getGradeFromAccuracy(accuracy) {
@@ -985,5 +986,40 @@ exports.serializeRanking = function(user) {
     avgCombo, avgAccuracy,
     playTime, onlineTime,
     performance, ranking, gold, sCount, aCount, bCount, cCount, dCount, fCount,
+  };
+};
+
+/** @type {import('mongoose').Model<Object>} */
+exports.Event = mongoose.model('Event', new mongoose.Schema({
+  startDate: Date,
+  endDate: Date,
+  name: String,
+  desc: String,
+  midiIds: [ObjectId],
+  active: Boolean,
+  coverPath: String,
+}));
+
+exports.serializeEvent = function(Event) {
+  const {
+    _id,
+    startDate, endDate, name, desc, midiIds, active, coverPath, midis,
+  } = Event;
+
+  return {
+    id: _id,
+    startDate, endDate, name, desc, midiIds, active, coverUrl: BUCKET_URL + coverPath, midis,
+  };
+};
+
+exports.createDefaultEvent = function() {
+  return {
+    startDate: null,
+    endDate: null,
+    name: '',
+    desc: '',
+    midiIds: [],
+    active: false,
+    coverPath: '',
   };
 };

--- a/src/models.js
+++ b/src/models.js
@@ -996,19 +996,18 @@ exports.Event = mongoose.model('Event', new mongoose.Schema({
   name: String,
   desc: String,
   midiIds: [ObjectId],
-  active: Boolean,
   coverPath: String,
 }));
 
 exports.serializeEvent = function(Event) {
   const {
     _id,
-    startDate, endDate, name, desc, midiIds, active, coverPath, midis,
+    startDate, endDate, name, desc, midiIds, coverPath, midis,
   } = Event;
 
   return {
     id: _id,
-    startDate, endDate, name, desc, midiIds, active, coverUrl: BUCKET_URL + coverPath, midis,
+    startDate, endDate, name, desc, midiIds, coverUrl: BUCKET_URL + coverPath, midis,
   };
 };
 
@@ -1019,7 +1018,6 @@ exports.createDefaultEvent = function() {
     name: '',
     desc: '',
     midiIds: [],
-    active: false,
     coverPath: '',
   };
 };

--- a/src/services/RoleService.js
+++ b/src/services/RoleService.js
@@ -4,6 +4,7 @@ const ROLE_MIDI_ADMIN = 'midi-admin';
 const ROLE_CARD_MOD = 'card-mod';
 const ROLE_CARD_ADMIN = 'card-admin';
 const ROLE_CARDPOOL_MOD = 'cardPool-mod';
+const ROLE_EVENT_MOD = 'event-mod';
 const ROLE_TRANSLATION_MOD = 'translation-mod';
 const ROLE_SITE_OWNER = 'site-owner';
 const ROLE_ROOT = 'root';
@@ -12,6 +13,7 @@ exports.ROLE_MIDI_ADMIN = ROLE_MIDI_ADMIN;
 exports.ROLE_CARD_MOD = ROLE_CARD_MOD;
 exports.ROLE_CARD_ADMIN = ROLE_CARD_ADMIN;
 exports.ROLE_CARDPOOL_MOD = ROLE_CARDPOOL_MOD;
+exports.ROLE_EVENT_MOD = ROLE_EVENT_MOD;
 exports.ROLE_TRANSLATION_MOD = ROLE_TRANSLATION_MOD;
 exports.ROLE_SITE_OWNER = ROLE_SITE_OWNER;
 exports.ROLE_ROOT = ROLE_ROOT;
@@ -24,6 +26,8 @@ const ROLE_PARENT_DICT = {
   [ROLE_CARD_ADMIN]: ROLE_SITE_OWNER,
 
   [ROLE_CARDPOOL_MOD]: ROLE_SITE_OWNER,
+
+  [ROLE_EVENT_MOD]: ROLE_SITE_OWNER,
 
   [ROLE_TRANSLATION_MOD]: ROLE_SITE_OWNER,
 


### PR DESCRIPTION
Add event create, update, can specify startDate, endDate, name, desc, midiIds, active, coverUrl.
Allow users to see event ranking, self ranking, and event midi list on event detail page.
If a play's midi is one of the currently active event's midis, reward users gold and add event Id when creating a trial from the play.